### PR TITLE
Update to build.zig API after `LazyPath` rework

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub fn build(b: *std.Build) void {
     });
     const t = lib.target_info.target;
 
-    lib.addIncludePath("include");
+    lib.addIncludePath(.{ .path = "include" });
     lib.addCSourceFiles(&generic_src_files, &.{});
     lib.defineCMacro("SDL_USE_BUILTIN_OPENGL_DEFINITIONS", "1");
     lib.linkLibC();


### PR DESCRIPTION
Built with Zig v0.11.0-dev.4332+43b830415.