### PR TITLE
define USING_GENERATED_CONFIG_H C macro when applicable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -73,6 +73,9 @@ pub fn build(b: *std.Build) void {
         lib.installHeadersDirectory(b.path("include-pregen"), "SDL2", .{});
         lib.addCSourceFiles(.{ .files = render_driver_sw.src_files });
     } else {
+        // causes pregenerated SDL_config.h to assert an error
+        lib.defineCMacro("USING_GENERATED_CONFIG_H", "");
+
         var files = std.ArrayList([]const u8).init(b.allocator);
         defer files.deinit();
 


### PR DESCRIPTION
The pregenerated SDL_config.h header checks if USING_GENERATED_CONFIG_H is defined and if so asserts an error.  This PR modifies build.zig to define this C macro when we are not supposed to be using the pregenerated SDL_config.h header.

Tested that VVVVVV still builds with this on linux/windows.