### PR TITLE
add missing include-pregen directory in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,6 +9,7 @@
         "build.zig",
         "build.zig.zon",
         "include",
+        "include-pregen",
         "src",
     },
 }


### PR DESCRIPTION
Missed adding this entry to the `build.zig.zon` file.  Missed it during testing because to test it I was manually overriding the `sdl` entry in the `VVVVVV` build.zig.zon file via a `.path` so it had access to all files even if they weren't in the zon file.

In the future I can test this better by pushing the changes to github and updating the URL in the build.zig.zon file.  This does take more steps so I'll have to remember to do this as a final test step.

P.S. would be great if zig's build system enforced no paths are accessed outside of the ones declared in `build.zig.zon`