### PR TITLE
don't assume windows gaming input available for mingw

### DIFF
--- a/include/SDL_config_windows.h
+++ b/include/SDL_config_windows.h
@@ -93,7 +93,7 @@ typedef unsigned int uintptr_t;
 #define HAVE_DXGI_H 1
 #define HAVE_XINPUT_H 1
 #if defined(_WIN32_MAXVER) && _WIN32_MAXVER >= 0x0A00  /* Windows 10 SDK */
-#if !defined(__MINGW32__) /* in zig version 0.14.0-dev.2628+5b5c60f43, this header isn't found by default (I haven't looked further into it) */
+#if !defined(__MINGW32__) /* Header removed from Zig 0.14.0-dev in https://github.com/ziglang/zig/pull/22156 */
 #define HAVE_WINDOWS_GAMING_INPUT_H 1
 #endif
 #endif

--- a/include/SDL_config_windows.h
+++ b/include/SDL_config_windows.h
@@ -93,7 +93,9 @@ typedef unsigned int uintptr_t;
 #define HAVE_DXGI_H 1
 #define HAVE_XINPUT_H 1
 #if defined(_WIN32_MAXVER) && _WIN32_MAXVER >= 0x0A00  /* Windows 10 SDK */
+#if !defined(__MINGW32__) /* in zig version 0.14.0-dev.2628+5b5c60f43, this header isn't found by default (I haven't looked further into it) */
 #define HAVE_WINDOWS_GAMING_INPUT_H 1
+#endif
 #endif
 #if defined(_WIN32_MAXVER) && _WIN32_MAXVER >= 0x0602  /* Windows 8 SDK */
 #define HAVE_D3D11_H 1


### PR DESCRIPTION
In updating dvui to zig version `0.14.0-dev.2628+5b5c60f43`, on Windows I encountered the following build error:

```
...\zig\p\1220c3a9f874bda11563c0f1e7fa5bfab0f7378af40310dcd49426e7d1afe9483fb6\src/joystick/windows/SDL_windows_gaming_input.c:35:10: error: 'windows.gaming.input.h' file not found
#include "windows.gaming.input.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~
...\zig\p\1220c3a9f874bda11563c0f1e7fa5bfab0f7378af40310dcd49426e7d1afe9483fb6\src/joystick/windows/SDL_rawinputjoystick.c:67:10: error: 'windows.gaming.input.h' file not found
#include "windows.gaming.input.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't have MSVC installed, and I guess zig compiling via mingw headers doesn't provide this header.
Therefore to make the build succeed, I had to adjust this predefined macro not to assume the header is present.

Having build.zig options/integration for this would probably be preferable, however,
for whatever reason for `.windows` os tag the pregenerated config is chosen,
and I didn't want to touch any of that logic without the necessary context,
so this seemed like the minimal fix.

As far as I understand, `__MINGW32__` shouldn't be defined when compiling for `msvc` ABI (which I assume includes the header),
so behavior should be the same for that target.