### PR TITLE
Remove Zig development builds from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zig-version: [0.13.0, master]
+        zig-version: [0.13.0]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The `build.zig.zon` format for upcoming Zig 0.14.0 has diverged in a way that is not backwards compatible with Zig 0.13.0. Only test against 0.13.0 for now.