### PR TITLE
Update build.zig for 0.16 fs.Dir -> Io.Dir

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -67,13 +67,28 @@ pub fn build(b: *std.Build) void {
             const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
             defer b.allocator.free(cache_include);
 
-            // TODO: Remove compatibility shim when Zig 0.16.0 is the minimum required version.
-            const open_dir_opts: std.Io.Dir.OpenOptions = if (@hasField(std.Io.Dir.OpenOptions, "follow_symlinks"))
-                .{ .access_sub_paths = true, .follow_symlinks = false }
-            else
-                .{ .access_sub_paths = true, .no_follow = true };
-            var dir = std.Io.Dir.openDirAbsolute(mod.owner.graph.io, cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
-            dir.close(mod.owner.graph.io);
+            if (@hasDecl(std.Io, "Dir")) {
+                // v0.16 -> Dir moved to std.Io
+                const open_dir_opts: std.Io.Dir.OpenOptions = .{
+                    .access_sub_paths = true,
+                    .follow_symlinks = false,
+                };
+
+                var dir = std.Io.Dir.openDirAbsolute(mod.owner.graph.io, cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
+
+                dir.close(mod.owner.graph.io);
+            } else if (@hasDecl(std.fs, "Dir")) {
+                // <=0.15.2 -> Dir on std.fs
+                // TODO: Remove compatibility shim when Zig 0.16.0 is the minimum required version.
+                const open_dir_opts: std.fs.Dir.OpenOptions = if (@hasField(std.fs.Dir.OpenOptions, "follow_symlinks"))
+                    .{ .access_sub_paths = true, .follow_symlinks = false }
+                else
+                    .{ .access_sub_paths = true, .no_follow = true };
+
+                var dir = std.fs.openDirAbsolute(cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
+
+                dir.close();
+            }
 
             mod.addIncludePath(.{ .cwd_relative = cache_include });
         },

--- a/build.zig
+++ b/build.zig
@@ -67,27 +67,22 @@ pub fn build(b: *std.Build) void {
             const cache_include = std.fs.path.join(b.allocator, &.{ b.sysroot.?, "cache", "sysroot", "include" }) catch @panic("Out of memory");
             defer b.allocator.free(cache_include);
 
+            // TODO: Remove compatibility shim when minimum Zig version is 0.16.0.
             if (@hasDecl(std.Io, "Dir")) {
-                // v0.16 -> Dir moved to std.Io
-                const open_dir_opts: std.Io.Dir.OpenOptions = .{
+                // Zig 0.16.0-dev
+                var dir = std.Io.Dir.openDirAbsolute(mod.owner.graph.io, cache_include, .{
                     .access_sub_paths = true,
                     .follow_symlinks = false,
-                };
-
-                var dir = std.Io.Dir.openDirAbsolute(mod.owner.graph.io, cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
-
+                }) catch @panic("No emscripten cache. Generate it!");
                 dir.close(mod.owner.graph.io);
             } else if (@hasDecl(std.fs, "Dir")) {
-                // <=0.15.2 -> Dir on std.fs
-                const open_dir_opts: std.fs.Dir.OpenOptions = .{
+                // Zig 0.15.x
+                var dir = std.fs.openDirAbsolute(cache_include, .{
                     .access_sub_paths = true,
-                    .follow_symlinks = false,
-                };
-
-                var dir = std.fs.openDirAbsolute(cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
-
+                    .no_follow = true,
+                }) catch @panic("No emscripten cache. Generate it!");
                 dir.close();
-            }
+            } else @compileError("Fix `openDirAbsolute` compatibility shim");
 
             mod.addIncludePath(.{ .cwd_relative = cache_include });
         },

--- a/build.zig
+++ b/build.zig
@@ -79,11 +79,10 @@ pub fn build(b: *std.Build) void {
                 dir.close(mod.owner.graph.io);
             } else if (@hasDecl(std.fs, "Dir")) {
                 // <=0.15.2 -> Dir on std.fs
-                // TODO: Remove compatibility shim when Zig 0.16.0 is the minimum required version.
-                const open_dir_opts: std.fs.Dir.OpenOptions = if (@hasField(std.fs.Dir.OpenOptions, "follow_symlinks"))
-                    .{ .access_sub_paths = true, .follow_symlinks = false }
-                else
-                    .{ .access_sub_paths = true, .no_follow = true };
+                const open_dir_opts: std.fs.Dir.OpenOptions = .{
+                    .access_sub_paths = true,
+                    .follow_symlinks = false,
+                };
 
                 var dir = std.fs.openDirAbsolute(cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
 

--- a/build.zig
+++ b/build.zig
@@ -68,12 +68,12 @@ pub fn build(b: *std.Build) void {
             defer b.allocator.free(cache_include);
 
             // TODO: Remove compatibility shim when Zig 0.16.0 is the minimum required version.
-            const open_dir_opts: std.fs.Dir.OpenOptions = if (@hasField(std.fs.Dir.OpenOptions, "follow_symlinks"))
+            const open_dir_opts: std.Io.Dir.OpenOptions = if (@hasField(std.Io.Dir.OpenOptions, "follow_symlinks"))
                 .{ .access_sub_paths = true, .follow_symlinks = false }
             else
                 .{ .access_sub_paths = true, .no_follow = true };
-            var dir = std.fs.openDirAbsolute(cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
-            dir.close();
+            var dir = std.Io.Dir.openDirAbsolute(mod.owner.graph.io, cache_include, open_dir_opts) catch @panic("No emscripten cache. Generate it!");
+            dir.close(mod.owner.graph.io);
 
             mod.addIncludePath(.{ .cwd_relative = cache_include });
         },


### PR DESCRIPTION
I'm not sure if this will break existing 0.15.2 builds. I'm not familiar enough with zig's build system to know if there is a way to get information about the zig compiler version to branch off of. If so, then this could easily be patched to support both 0.16 and 0.15.2. As is, it's likely going to break and shouldn't be merged until 0.16 is released. 

Maybe a temporary dev branch for zig16 would be useful?